### PR TITLE
Update example.py

### DIFF
--- a/webhdfs/example.py
+++ b/webhdfs/example.py
@@ -1,4 +1,4 @@
-from webhdfs import WebHDFS
+from webhdfs.webhdfs import WebHDFS
 import os, tempfile
 import time
 


### PR DESCRIPTION
The import `from webhdfs import WebHDFS` doesn't work when installed via pip. Fixed it.
